### PR TITLE
Pretty Print 

### DIFF
--- a/app/linked_list.rb
+++ b/app/linked_list.rb
@@ -5,12 +5,8 @@ class LinkedList
     @head = Node.new(value, nil)
   end
 
-  def is_empty?
-    @head.value.nil? ? true : false
-  end
-
   def size
-    return 0 if is_empty?
+    return 0 if @head.is_empty?
 
     count = 1
     while @head.next_node != nil
@@ -21,7 +17,7 @@ class LinkedList
   end
 
   def push(data)
-    if is_empty?
+    if @head.is_empty?
       @head = Node.new(data)
     else
       new_node = Node.new(data)

--- a/app/node.rb
+++ b/app/node.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class Node
-  attr_accessor :value, :next_node
+  attr_accessor :value, :next_node, :is_empty
 
   def initialize(value, next_node = nil)
     @value = value
     @next_node = next_node
+  end
+
+  def is_empty?
+    @is_empty = @value.nil?
   end
 end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -10,13 +10,6 @@ class LinkedListTest < Minitest::Test
     assert_instance_of(LinkedList, LinkedList.new('string'))
   end
 
-  # is_empty?: return true if the linked list is empty
-  def test_it_knows_when_its_empty
-    list = LinkedList.new(nil)
-
-    assert_equal(list.is_empty?, true)
-  end
-
   # size: return the length of linked list
   def test_it_knows_its_length
     list = LinkedList.new('string')

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -7,4 +7,12 @@ class NodeTest < Minitest::Test
   def test_it_exists
     assert_instance_of(Node, Node.new('string'))
   end
+
+  def test_it_knows_when_its_empty
+    empty_node = Node.new(nil)
+    full_node = Node.new(1)
+
+    assert_equal(empty_node.is_empty?, true)
+    assert_equal(full_node.is_empty?, false)
+  end
 end


### PR DESCRIPTION
Moves is empty? method to node class
Corrects push method bug to account for current node in while loop, previously it was only remembering the first node because of it's scope in the loop
Implements pretty print method with testing